### PR TITLE
Add Web Demo & Docker environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ CLIP-GEN 是一个 Language-Free 的文本生成图像的方法，它不依赖�
     python train_gpt.py --ds coco --vqgan_ckpt /path/to/vqgan/ckpt
     ```
 
+## Web Demo
+
+Replicate web demo [![Replicate](https://replicate.com/hfailab/clip-gen/badge)](https://replicate.com/hfailab/clip-gen)
+
+
 ## Demo
 
 下载在 COCO 上训练好的 [VQGAN](https://github.com/HFAiLab/clip-gen/releases/download/v0.1.0/vqgan_coco.pt) 和 [GPT](https://github.com/HFAiLab/clip-gen/releases/download/v0.1.0/gpt_coco.pt) 模型，分别放到 `pretrained/vqgan_coco.pt` 和 `pretrained/gpt_coco.pt`；然后运行：

--- a/README_en.md
+++ b/README_en.md
@@ -34,6 +34,10 @@ Supported datasets：`coco`, `imagenet`, `googlecc`
     ```shell
     python train_gpt.py --ds coco --vqgan_ckpt /path/to/vqgan/ckpt
     ```
+## Web Demo
+
+Try Replicate web demo here [![Replicate](https://replicate.com/hfailab/clip-gen/badge)](https://replicate.com/hfailab/clip-gen)
+
 
 ## Demo
 

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,15 @@
+build:
+  cuda: "11.0"
+  gpu: true
+  python_version: "3.8"
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+  python_packages:
+    - "ipython==7.21.0"
+    - "torch==1.10.1"
+    - "torchvision==0.11.2"
+    - "matplotlib==3.4.3"
+    - "regex==2022.4.24"
+
+predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,131 @@
+import tempfile
+import matplotlib.pyplot as plt
+import torch
+import torch.nn.functional as F
+from torchvision.utils import make_grid
+from cog import BasePredictor, Path, Input
+
+from models.vqgan import VQGAN
+from models.clip import clip_vit_b32
+from models.gpt import __dict__ as models
+from tokenizer import tokenize
+from utils import CLIPWrapper
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+
+        torch.set_grad_enabled(False)
+        self.device = torch.device('cuda', 0)
+        gpt_name = "gpt2_medium"
+        dataset_name = "coco"
+
+        codebook_size = 16384
+        embed_dim = 256
+        dropout = 0.1
+        normalize_clip = True
+
+        batch_size = 8
+        vqgan_ckpt = f"pretrained/vqgan_{dataset_name}.pt"
+        gpt_ckpt = f"pretrained/gpt_{dataset_name}.pt"
+
+        ##################################
+        # VQGAN
+        ##################################
+        self.vqgan = VQGAN(codebook_size, embed_dim).to(self.device).eval()
+        state = torch.load(vqgan_ckpt, map_location='cpu')
+        self.vqgan.load_state_dict(state['model'])
+        print(f"Loaded VQGAN model from {vqgan_ckpt}, epoch {state['epoch']}")
+
+        ##################################
+        # GPT
+        ##################################
+        self.gpt = models[gpt_name](vocab_size=codebook_size, dropout=dropout).to(self.device).eval()
+        state = torch.load(gpt_ckpt, map_location='cpu')
+        self.gpt.load_state_dict(state['model'])
+        print(f"Loaded GPT model from {gpt_ckpt}, epoch {state['epoch']}")
+
+        ##################################
+        # CLIP
+        ##################################
+        self.clip = clip_vit_b32(pretrained=True).to(self.device).eval()
+        self.clip = CLIPWrapper(self.clip, normalize=normalize_clip)
+
+    def predict(
+        self,
+        text: str = Input(
+            description="Text for generating image.",
+            default="A train being operated on a train track"
+        ),
+        num_samples: int = Input(
+            description="Number of samples to generate.",
+            default=8,
+            ge=1,
+            le=8
+        ),
+    ) -> Path:
+
+        mean = (0.5, 0.5, 0.5)
+        std = (0.5, 0.5, 0.5)
+
+        candidate_size = 32
+        top_k = 500
+        top_p = 0.95
+        bs = 8  # batch size
+        assert candidate_size % bs == 0
+
+        texts = [text]
+        texts = tokenize(texts).to(self.device)
+
+        x_recons = []
+
+        text_embeddings = self.clip.encode_text(texts)  # [1, 512]
+        embeds = text_embeddings.expand(bs, -1)
+        for i in range(candidate_size // bs):
+            z_idx = self.gpt.sample(embeds, steps=16 * 16, top_k=top_k, top_p=top_p)  # [-1, 16*16]
+            z_idx = z_idx.view(-1, 16, 16)
+            z = self.vqgan.quantizer.decode(z_idx)  # (B, H, W, C)
+            z = z.permute(0, 3, 1, 2)  # [B, C, H, W]
+            x_recon = self.vqgan.decode(z)  # [B, 3, H, W]
+            x_recons.append(x_recon)
+
+        # torch.cuda.empty_cache()
+        x_recon = torch.cat(x_recons, dim=0)
+
+        ##################################
+        # filter by CLIP
+        ##################################
+
+        clip_x_recon = F.interpolate(x_recon, 224, mode='bilinear')
+
+        img_embeddings = []
+
+        for i in range(candidate_size // bs):
+            embd = self.clip.encode_image(clip_x_recon[i * bs:(i + 1) * bs])  # [B, 512]
+            img_embeddings.append(embd)
+            torch.cuda.empty_cache()
+        img_embeddings = torch.cat(img_embeddings, dim=0)
+
+        sim = F.cosine_similarity(text_embeddings, img_embeddings)
+        topk = sim.argsort(descending=True)[:num_samples]
+        print("CLIP similarity", sim[topk])
+
+        ##################################
+        # save image
+        ##################################
+
+        out_path = Path(tempfile.mkdtemp()) / "output.png"
+        x = x_recon[topk]
+        std = torch.tensor(std).view(1, -1, 1, 1).to(x)
+        mean = torch.tensor(mean).view(1, -1, 1, 1).to(x)
+        img = x.clone()  # [2 * N, 3, H, W]
+        img = img * std + mean
+        print(img)
+        print(type(img))
+        img = make_grid(img, nrow=min(x.size(0), 4))
+        img = img.permute(1, 2, 0).clamp(0, 1)
+        plt.imshow(img.cpu())
+        plt.title(text)
+        plt.axis('off')
+        plt.savefig(str(out_path), bbox_inches='tight')
+        return out_path


### PR DESCRIPTION
This pull request makes it possible to run your model inside a Docker environment, which makes it easier for other people to run it.  We're using an open source tool called [Cog](https://github.com/replicate/cog) to make this process easier.

This also means we can make a web page where other people can try out your model, view it here: https://replicate.com/hfailab/clip-gen. You can find the docker file under the tab ‘run model with docker’. 

We have added some examples to the page, but do claim the page so you can own the page, customise the [Example](https://replicate.com/hfailab/clip-gen/examples) gallery as you like, push any future update to the web demo, and we'll feature it on our website and tweet about it too. You can find the 'Claim this model' button on the top of the page. Any member of the HFAiLab organization on GitHub can claim the model ~ When the page is claimed, it will be automatically linked to the arXiv website as well (under “Demos”).

In case you're wondering who I am, I'm from [Replicate](https://replicate.com/home), where we're trying to make machine learning reproducible. We got frustrated that we couldn't run all the really interesting ML work being done. So, we're going round implementing models we like. 😊
